### PR TITLE
Fix constant name in rollout types

### DIFF
--- a/pkg/types/rollout.go
+++ b/pkg/types/rollout.go
@@ -11,7 +11,7 @@ const (
 	PhaseRunning   RolloutPhase = "Running"
 	PhaseSucceeded RolloutPhase = "Succeeded"
 	PhaseFailed    RolloutPhase = "Failed"
-	PhaseErrir     RolloutPhase = "Error"
+       PhaseError     RolloutPhase = "Error"
 )
 
 type RpcRolloutResult struct {
@@ -29,7 +29,7 @@ type RpcRolloutContext struct {
 
 func (p RolloutPhase) Validate() error {
 	switch p {
-	case PhaseRunning, PhaseSucceeded, PhaseFailed, PhaseErrir:
+       case PhaseRunning, PhaseSucceeded, PhaseFailed, PhaseError:
 		return nil
 	default:
 		return fmt.Errorf("invalid phase: %s", p)


### PR DESCRIPTION
## Summary
- rename `PhaseErrir` constant to `PhaseError`
- update validation case to use `PhaseError`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840afd2827c832887e280b86468ab1a